### PR TITLE
update dependencies and format to 0.9.1

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,10 +15,11 @@
     "output"
   ],
   "dependencies": {
-    "purescript-console": "^0.1.0",
-    "purescript-coroutines": "^0.5.0",
-    "purescript-freet": "^0.3.0",
-    "purescript-tailrec": "^0.3.1",
-    "purescript-transformers": "^0.8.2"
+    "purescript-console": "^1.0.0",
+    "purescript-coroutines": "^1.0.0",
+    "purescript-freet": "^1.0.0",
+    "purescript-tailrec": "^1.0.0",
+    "purescript-transformers": "^1.0.0",
+    "purescript-prelude": "^1.0.1"
   }
 }

--- a/src/Control/Coroutine/Stalling.purs
+++ b/src/Control/Coroutine/Stalling.purs
@@ -9,6 +9,7 @@ module Control.Coroutine.Stalling
   , processToStallingProcess
   , runStallingProcess
 
+  , fuse
   , ($$?)
 
   , mapStallingProducer
@@ -76,17 +77,18 @@ stall =
   FT.liftFreeT (Stall unit)
 
 -- Fuse a `StallingProducer` with a `Consumer`.
-($$?)
+fuse
   :: forall o m a
    . (MR.MonadRec m)
   => StallingProducer o m a
   -> CR.Consumer o m a
   -> StallingProcess m a
-($$?) =
+fuse =
   CR.fuseWith \f q (CR.Await g) ->
     case q of
       Emit o a -> M.Just (f a (g o))
       Stall _ -> M.Nothing
+infix 0 fuse as $$?
 
 runStallingProcess
   :: forall m a


### PR DESCRIPTION
I was going through the dependencies for halogen and found this hadn't been updated. No build errors when I run this on my machine, and it spits out numbers smoothly when running the test.
